### PR TITLE
Removed unused parameter and unused import

### DIFF
--- a/reader/dataset.py
+++ b/reader/dataset.py
@@ -9,7 +9,7 @@ import functools
 import random
 from typing import Optional
 
-from fsspec.implementations.local import LocalFileSystem
+from fsspec.implementations.local
 import pyarrow.dataset as pads
 import pyarrow as pa
 import pyarrow.parquet
@@ -105,7 +105,7 @@ class Dataset(torch.utils.data.IterableDataset):
   def dataloader(self, remote: bool = False):
     if not remote:
       return map(self.pa_to_batch, self.to_batches())
-    readers = get_readers(2)
+    readers = get_readers()
     return map(self.pa_to_batch, reader_utils.roundrobin(*readers))
 
 
@@ -116,7 +116,7 @@ GRPC_OPTIONS = [
 ]
 
 
-def get_readers(num_readers_per_worker: int):
+def get_readers():
   addresses = env.get_flight_server_addresses()
 
   readers = []


### PR DESCRIPTION
1. Removed unused parameter from the get_readers(). The `num_readers_per_worker parameter` is not being used inside the `get_readers` function, and it appears to be an unused parameter.

The function creates one reader per worker, so `num_readers_per_worker` does not seem to have any effect on the behavior of the function. It's possible that this parameter was intended to be used in some way but was later removed or overlooked.

Therefore, `num_readers_per_worker` appears to be an unnecessary parameter and can be removed from the function signature.

2. Removed unused import `LocalFileSystem`. `LocalFileSystem` from `fsspec.implementations.local` is imported but not used in the code.