### PR TITLE
Patch: TensorFlow has a heap out-of-buffer read vulnerability in the QuantizeAndDequantize operation

### DIFF
--- a/images/requirements.txt
+++ b/images/requirements.txt
@@ -124,7 +124,7 @@ tabulate==0.9.0
 tensorboard==2.9.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
-tensorflow==2.9.3
+tensorflow==2.11.1
 tensorflow-estimator==2.9.0
 tensorflow-io-gcs-filesystem==0.30.0
 termcolor==2.2.0


### PR DESCRIPTION
Attackers using Tensorflow can exploit the vulnerability. They can access heap memory which is not in the control of user, leading to a crash or RCE.
When axis is larger than the dim of input, c->Dim(input,axis) goes out of bound.
Same problem occurs in the QuantizeAndDequantizeV2/V3/V4/V4Grad operations too.