### PR TITLE
Check for any non-Linux platform rather than just macOS

### DIFF
--- a/images/init_venv.sh
+++ b/images/init_venv.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-if [[ "$(uname)" == "Darwin" ]]; then
+if [[ "$(uname)" != "Linux" ]]; then
   echo "Only supported on Linux."
   exit 1
 fi


### PR DESCRIPTION
Many other *Nix platforms besides macOS/Darwin and Linux exist; since these ML models are meant to be Linux-only, we replace the check for Darwin in the venv init script with a check for any non-Linux OS.