### PR TITLE
Swap python list for torch's ModuleList

### DIFF
--- a/projects/home/recap/model/mlp.py
+++ b/projects/home/recap/model/mlp.py
@@ -18,7 +18,7 @@ class Mlp(torch.nn.Module):
     self._mlp_config = mlp_config
     input_size = in_features
     layer_sizes = mlp_config.layer_sizes
-    modules = []
+    modules = torch.nn.ModuleList()
     for layer_size in layer_sizes[:-1]:
       modules.append(torch.nn.Linear(input_size, layer_size, bias=True))
 


### PR DESCRIPTION
Swaps python's list for torch's ModuleList so all the layers in MLP are properly registered. (for more info see https://pytorch.org/docs/stable/generated/torch.nn.ModuleList.html#modulelist).
 